### PR TITLE
feat: Conflict-free Replicated Data Type(CRDT)

### DIFF
--- a/kiradb-crdt/src/main/java/io/kiradb/crdt/CrdtStore.java
+++ b/kiradb-crdt/src/main/java/io/kiradb/crdt/CrdtStore.java
@@ -1,0 +1,273 @@
+package io.kiradb.crdt;
+
+import io.kiradb.core.storage.StorageEngine;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Owner of named CRDT instances, with read-through and write-through to a {@link StorageEngine}.
+ *
+ * <p>Each CRDT is identified by a name (the user-facing key) and a type. Names live
+ * in disjoint namespaces per type — a GCounter named "votes" is unrelated to an
+ * ORSet named "votes". On disk, CRDT bytes are stored under reserved key prefixes
+ * so they coexist with ordinary RESP3 keys without collision.
+ *
+ * <h2>Concurrency</h2>
+ * CRDT instances are individually thread-safe (their {@code merge}/{@code set}
+ * methods synchronize internally). The {@code computeIfAbsent} on the in-memory
+ * cache makes load-or-create atomic. Persistence happens after each mutation
+ * via {@link #persist(String, byte[])}.
+ *
+ * <h2>NodeId stability</h2>
+ * The {@code localNodeId} passed to the constructor must be stable across restarts.
+ * A drifting node id splits one logical node into two, doubling counters and
+ * resurrecting elements. Reuse the Raft node id from {@code kiradb-raft}.
+ */
+public final class CrdtStore {
+
+    private static final String GCOUNTER_PREFIX = "crdt:g:";
+    private static final String PNCOUNTER_PREFIX = "crdt:pn:";
+    private static final String LWW_PREFIX = "crdt:lww:";
+    private static final String MV_PREFIX = "crdt:mv:";
+    private static final String ORSET_PREFIX = "crdt:or:";
+
+    private final StorageEngine storage;
+    private final String localNodeId;
+
+    private final ConcurrentMap<String, GCounter> gCounters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, PNCounter> pnCounters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, LWWRegister> lwwRegisters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, MVRegister> mvRegisters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ORSet> orSets = new ConcurrentHashMap<>();
+
+    /**
+     * Create a CRDT store backed by the given storage engine.
+     *
+     * @param storage     storage engine for persistence
+     * @param localNodeId stable node identity (must match across restarts)
+     */
+    public CrdtStore(final StorageEngine storage, final String localNodeId) {
+        this.storage = storage;
+        this.localNodeId = localNodeId;
+    }
+
+    // --- GCounter -----------------------------------------------------------
+
+    /**
+     * Get or lazily load a GCounter with the given name.
+     *
+     * @param name CRDT name
+     * @return the existing or newly created counter
+     */
+    public GCounter gCounter(final String name) {
+        return gCounters.computeIfAbsent(name, n -> {
+            byte[] key = (GCOUNTER_PREFIX + n).getBytes(StandardCharsets.UTF_8);
+            Optional<byte[]> bytes = storage.get(key);
+            return bytes.map(b -> GCounter.deserialize(localNodeId, b))
+                    .orElseGet(() -> new GCounter(localNodeId));
+        });
+    }
+
+    /**
+     * Increment a GCounter by {@code delta}, persist, and return the new value.
+     *
+     * @param name  CRDT name
+     * @param delta amount to add (must be positive)
+     * @return value after increment
+     */
+    public long gCounterIncrement(final String name, final long delta) {
+        GCounter c = gCounter(name);
+        synchronized (c) {
+            c.increment(delta);
+            persistGCounter(name, c);
+            return c.value();
+        }
+    }
+
+    /**
+     * @param name CRDT name
+     * @return current GCounter value (0 if absent)
+     */
+    public long gCounterValue(final String name) {
+        return gCounter(name).value();
+    }
+
+    private void persistGCounter(final String name, final GCounter c) {
+        byte[] key = (GCOUNTER_PREFIX + name).getBytes(StandardCharsets.UTF_8);
+        storage.put(key, c.serialize());
+    }
+
+    // --- PNCounter ----------------------------------------------------------
+
+    /**
+     * Get or lazily load a PNCounter.
+     *
+     * @param name CRDT name
+     * @return PNCounter instance
+     */
+    public PNCounter pnCounter(final String name) {
+        return pnCounters.computeIfAbsent(name, n -> {
+            byte[] key = (PNCOUNTER_PREFIX + n).getBytes(StandardCharsets.UTF_8);
+            Optional<byte[]> bytes = storage.get(key);
+            return bytes.map(b -> PNCounter.deserialize(localNodeId, b))
+                    .orElseGet(() -> new PNCounter(localNodeId));
+        });
+    }
+
+    /**
+     * Apply a signed delta and persist.
+     *
+     * @param name  CRDT name
+     * @param delta signed delta
+     * @return value after applying delta
+     */
+    public long pnCounterAdd(final String name, final long delta) {
+        PNCounter c = pnCounter(name);
+        synchronized (c) {
+            c.add(delta);
+            byte[] key = (PNCOUNTER_PREFIX + name).getBytes(StandardCharsets.UTF_8);
+            storage.put(key, c.serialize());
+            return c.value();
+        }
+    }
+
+    /**
+     * @param name CRDT name
+     * @return signed value (0 if absent)
+     */
+    public long pnCounterValue(final String name) {
+        return pnCounter(name).value();
+    }
+
+    // --- LWWRegister --------------------------------------------------------
+
+    /**
+     * Get or lazily load an LWWRegister.
+     *
+     * @param name CRDT name
+     * @return LWWRegister instance
+     */
+    public LWWRegister lwwRegister(final String name) {
+        return lwwRegisters.computeIfAbsent(name, n -> {
+            byte[] key = (LWW_PREFIX + n).getBytes(StandardCharsets.UTF_8);
+            Optional<byte[]> bytes = storage.get(key);
+            return bytes.map(b -> LWWRegister.deserialize(localNodeId, b))
+                    .orElseGet(() -> new LWWRegister(localNodeId));
+        });
+    }
+
+    /**
+     * Set the value of an LWWRegister and persist.
+     *
+     * @param name  CRDT name
+     * @param value new value (may be null to clear)
+     */
+    public void lwwSet(final String name, final byte[] value) {
+        LWWRegister r = lwwRegister(name);
+        synchronized (r) {
+            r.set(value);
+            byte[] key = (LWW_PREFIX + name).getBytes(StandardCharsets.UTF_8);
+            storage.put(key, r.serialize());
+        }
+    }
+
+    /**
+     * @param name CRDT name
+     * @return current value (or null)
+     */
+    public byte[] lwwGet(final String name) {
+        return lwwRegister(name).get();
+    }
+
+    // --- MVRegister ---------------------------------------------------------
+
+    /**
+     * Get or lazily load an MVRegister.
+     *
+     * @param name CRDT name
+     * @return MVRegister instance
+     */
+    public MVRegister mvRegister(final String name) {
+        return mvRegisters.computeIfAbsent(name, n -> {
+            byte[] key = (MV_PREFIX + n).getBytes(StandardCharsets.UTF_8);
+            Optional<byte[]> bytes = storage.get(key);
+            return bytes.map(b -> MVRegister.deserialize(localNodeId, b))
+                    .orElseGet(() -> new MVRegister(localNodeId));
+        });
+    }
+
+    // --- ORSet --------------------------------------------------------------
+
+    /**
+     * Get or lazily load an ORSet.
+     *
+     * @param name CRDT name
+     * @return ORSet instance
+     */
+    public ORSet orSet(final String name) {
+        return orSets.computeIfAbsent(name, n -> {
+            byte[] key = (ORSET_PREFIX + n).getBytes(StandardCharsets.UTF_8);
+            Optional<byte[]> bytes = storage.get(key);
+            return bytes.map(ORSet::deserialize).orElseGet(ORSet::new);
+        });
+    }
+
+    /**
+     * Add an element to a named ORSet and persist.
+     *
+     * @param name    CRDT name
+     * @param element element to add
+     */
+    public void orSetAdd(final String name, final String element) {
+        ORSet s = orSet(name);
+        synchronized (s) {
+            s.add(element);
+            byte[] key = (ORSET_PREFIX + name).getBytes(StandardCharsets.UTF_8);
+            storage.put(key, s.serialize());
+        }
+    }
+
+    /**
+     * Remove an element from a named ORSet and persist.
+     *
+     * @param name    CRDT name
+     * @param element element to remove
+     * @return true if at least one tag was removed
+     */
+    public boolean orSetRemove(final String name, final String element) {
+        ORSet s = orSet(name);
+        synchronized (s) {
+            boolean removed = s.remove(element);
+            byte[] key = (ORSET_PREFIX + name).getBytes(StandardCharsets.UTF_8);
+            storage.put(key, s.serialize());
+            return removed;
+        }
+    }
+
+    // --- Generic merge helper for replication-incoming bytes -----------------
+
+    /**
+     * Merge incoming gossip bytes for a GCounter and persist.
+     *
+     * @param name  CRDT name
+     * @param bytes serialized GCounter from a peer
+     */
+    public void mergeGCounter(final String name, final byte[] bytes) {
+        GCounter incoming = GCounter.deserialize(localNodeId, bytes);
+        GCounter local = gCounter(name);
+        synchronized (local) {
+            local.merge(incoming);
+            persistGCounter(name, local);
+        }
+    }
+
+    /**
+     * @return the local node id this store stamps onto writes
+     */
+    public String localNodeId() {
+        return localNodeId;
+    }
+}

--- a/kiradb-crdt/src/main/java/io/kiradb/crdt/GCounter.java
+++ b/kiradb-crdt/src/main/java/io/kiradb/crdt/GCounter.java
@@ -1,0 +1,162 @@
+package io.kiradb.crdt;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Grow-only counter — a state-based CRDT.
+ *
+ * <p>State is a map from node id to a per-node monotonic counter. The counter's
+ * value is the sum of all per-node counters. Each node only ever increments its
+ * own slot; merging takes the element-wise max of the two maps.
+ *
+ * <h2>Why max-merge is safe</h2>
+ * Only node {@code N} ever writes slot {@code N}. So when two replicas disagree
+ * on slot {@code N}, the higher value strictly contains more information about
+ * what happened on N — taking the max is non-destructive.
+ *
+ * <h2>Limitations</h2>
+ * <ul>
+ *   <li>Only counts up. Use {@link PNCounter} if you need decrements.</li>
+ *   <li>Per-replica state grows with the number of nodes that have ever
+ *       incremented (not the number of increments). Bounded by cluster size.</li>
+ * </ul>
+ */
+public final class GCounter {
+
+    private static final byte FORMAT_VERSION = 1;
+
+    private final String localNodeId;
+    private final ConcurrentMap<String, Long> slots;
+
+    /**
+     * Create a fresh counter owned by the given node.
+     *
+     * @param localNodeId stable node identity (must match across restarts)
+     */
+    public GCounter(final String localNodeId) {
+        this.localNodeId = Objects.requireNonNull(localNodeId, "localNodeId");
+        this.slots = new ConcurrentHashMap<>();
+    }
+
+    private GCounter(final String localNodeId, final Map<String, Long> initial) {
+        this.localNodeId = Objects.requireNonNull(localNodeId, "localNodeId");
+        this.slots = new ConcurrentHashMap<>(initial);
+    }
+
+    /**
+     * Increment the local node's slot by 1.
+     */
+    public void increment() {
+        increment(1L);
+    }
+
+    /**
+     * Increment the local node's slot by {@code delta} (must be positive).
+     *
+     * @param delta amount to add (must be {@code > 0})
+     * @throws IllegalArgumentException if {@code delta <= 0}
+     */
+    public void increment(final long delta) {
+        if (delta <= 0) {
+            throw new IllegalArgumentException("GCounter delta must be positive, was " + delta);
+        }
+        slots.merge(localNodeId, delta, Long::sum);
+    }
+
+    /**
+     * Return the counter's current value: the sum of all per-node slots.
+     *
+     * @return total count
+     */
+    public long value() {
+        long sum = 0;
+        for (long v : slots.values()) {
+            sum += v;
+        }
+        return sum;
+    }
+
+    /**
+     * Merge another GCounter's state into this one (in place). Element-wise max.
+     *
+     * <p>Commutative, associative, idempotent — the three CRDT properties.
+     *
+     * @param other another counter (may be from a different node)
+     */
+    public synchronized void merge(final GCounter other) {
+        for (var entry : other.slots.entrySet()) {
+            slots.merge(entry.getKey(), entry.getValue(), Math::max);
+        }
+    }
+
+    /**
+     * @return read-only snapshot of the per-node slot map
+     */
+    public Map<String, Long> slotsSnapshot() {
+        return Collections.unmodifiableMap(new java.util.HashMap<>(slots));
+    }
+
+    /**
+     * Serialize this counter's state for gossip / disk persistence.
+     *
+     * <p>Format: {@code [version:byte] [count:int] N x ([utf:String] [val:long])}
+     *
+     * @return wire-format bytes
+     */
+    public byte[] serialize() {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeByte(FORMAT_VERSION);
+            out.writeInt(slots.size());
+            for (var entry : slots.entrySet()) {
+                out.writeUTF(entry.getKey());
+                out.writeLong(entry.getValue());
+            }
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Reconstruct a counter from its serialized state, owned locally by {@code localNodeId}.
+     *
+     * @param localNodeId   node identity to bind this instance to
+     * @param bytes         wire-format bytes from {@link #serialize()}
+     * @return reconstructed GCounter
+     */
+    public static GCounter deserialize(final String localNodeId, final byte[] bytes) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
+            byte version = in.readByte();
+            if (version != FORMAT_VERSION) {
+                throw new IllegalStateException(
+                        "Unknown GCounter format version: " + version);
+            }
+            int count = in.readInt();
+            Map<String, Long> initial = new java.util.HashMap<>(count);
+            for (int i = 0; i < count; i++) {
+                String node = in.readUTF();
+                long val = in.readLong();
+                initial.put(node, val);
+            }
+            return new GCounter(localNodeId, initial);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "GCounter{node=" + localNodeId + ", value=" + value() + ", slots=" + slots + "}";
+    }
+}

--- a/kiradb-crdt/src/main/java/io/kiradb/crdt/LWWRegister.java
+++ b/kiradb-crdt/src/main/java/io/kiradb/crdt/LWWRegister.java
@@ -1,0 +1,188 @@
+package io.kiradb.crdt;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * Last-Write-Wins register — a single value with a (timestamp, nodeId) version.
+ *
+ * <p>On merge, the entry with the higher timestamp wins. If timestamps tie, the
+ * lexicographically larger {@code nodeId} wins (deterministic tiebreak so all
+ * replicas converge to the same answer).
+ *
+ * <h2>The honest disclaimer</h2>
+ * Wall clocks lie. NTP drift, leap seconds, VM pauses, suspended laptops — any
+ * of these can cause a write to be silently discarded by a "newer" write that
+ * really happened earlier. For data where loss is unacceptable, use
+ * {@link MVRegister} instead and let the application resolve.
+ *
+ * <p>LWW is appropriate for: feature flag values, last-known-good config,
+ * "current value" of monitoring metrics. It is NOT appropriate for: shopping
+ * carts, audit logs, financial state.
+ */
+public final class LWWRegister {
+
+    private static final byte FORMAT_VERSION = 1;
+
+    private final String localNodeId;
+    private byte[] value;
+    private long timestampMillis;
+    private String writerNodeId;
+
+    /**
+     * Create an empty register owned by the given node.
+     *
+     * @param localNodeId node identity used as the tiebreaker on equal timestamps
+     */
+    public LWWRegister(final String localNodeId) {
+        this.localNodeId = Objects.requireNonNull(localNodeId, "localNodeId");
+        this.value = null;
+        this.timestampMillis = Long.MIN_VALUE;
+        this.writerNodeId = "";
+    }
+
+    private LWWRegister(
+            final String localNodeId,
+            final byte[] value,
+            final long timestampMillis,
+            final String writerNodeId) {
+        this.localNodeId = Objects.requireNonNull(localNodeId, "localNodeId");
+        this.value = value;
+        this.timestampMillis = timestampMillis;
+        this.writerNodeId = writerNodeId;
+    }
+
+    /**
+     * Write a new value, stamped with the current wall clock and local node id.
+     *
+     * @param newValue the new value (may be null to clear)
+     */
+    public void set(final byte[] newValue) {
+        set(newValue, System.currentTimeMillis());
+    }
+
+    /**
+     * Write a new value with an explicit timestamp (useful for tests and when
+     * the caller has a hybrid logical clock).
+     *
+     * @param newValue the new value (may be null to clear)
+     * @param timestamp epoch-millis tagged on this write
+     */
+    public synchronized void set(final byte[] newValue, final long timestamp) {
+        if (winsOver(timestamp, localNodeId, this.timestampMillis, this.writerNodeId)) {
+            this.value = newValue;
+            this.timestampMillis = timestamp;
+            this.writerNodeId = localNodeId;
+        }
+    }
+
+    /**
+     * @return current value, or null if never set
+     */
+    public synchronized byte[] get() {
+        return value;
+    }
+
+    /**
+     * @return timestamp of the current value
+     */
+    public synchronized long timestamp() {
+        return timestampMillis;
+    }
+
+    /**
+     * @return node id that wrote the current value
+     */
+    public synchronized String writer() {
+        return writerNodeId;
+    }
+
+    /**
+     * Merge another register's state into this one (in place).
+     *
+     * @param other another LWWRegister
+     */
+    public synchronized void merge(final LWWRegister other) {
+        if (winsOver(other.timestampMillis, other.writerNodeId,
+                this.timestampMillis, this.writerNodeId)) {
+            this.value = other.value;
+            this.timestampMillis = other.timestampMillis;
+            this.writerNodeId = other.writerNodeId;
+        }
+    }
+
+    /**
+     * Decide whether (tA, idA) wins over (tB, idB).
+     * Higher timestamp wins; ties broken by lexicographically larger node id.
+     */
+    private static boolean winsOver(
+            final long tA, final String idA,
+            final long tB, final String idB) {
+        if (tA > tB) {
+            return true;
+        }
+        if (tA < tB) {
+            return false;
+        }
+        return idA.compareTo(idB) > 0;
+    }
+
+    /**
+     * Serialize state.
+     *
+     * <p>Format: {@code [version:byte] [tsMillis:long] [writerId:utf] [hasValue:byte] (if 1: [len:int] [bytes])}.
+     *
+     * @return wire-format bytes
+     */
+    public synchronized byte[] serialize() {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeByte(FORMAT_VERSION);
+            out.writeLong(timestampMillis);
+            out.writeUTF(writerNodeId);
+            if (value == null) {
+                out.writeByte(0);
+            } else {
+                out.writeByte(1);
+                out.writeInt(value.length);
+                out.write(value);
+            }
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Reconstruct from serialized form.
+     *
+     * @param localNodeId local node identity
+     * @param bytes       output of {@link #serialize()}
+     * @return reconstructed register
+     */
+    public static LWWRegister deserialize(final String localNodeId, final byte[] bytes) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
+            byte version = in.readByte();
+            if (version != FORMAT_VERSION) {
+                throw new IllegalStateException(
+                        "Unknown LWWRegister format version: " + version);
+            }
+            long ts = in.readLong();
+            String writer = in.readUTF();
+            byte hasValue = in.readByte();
+            byte[] val = null;
+            if (hasValue == 1) {
+                int len = in.readInt();
+                val = in.readNBytes(len);
+            }
+            return new LWWRegister(localNodeId, val, ts, writer);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/kiradb-crdt/src/main/java/io/kiradb/crdt/MVRegister.java
+++ b/kiradb-crdt/src/main/java/io/kiradb/crdt/MVRegister.java
@@ -1,0 +1,230 @@
+package io.kiradb.crdt;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Multi-Value register — surfaces concurrent writes instead of silently picking one.
+ *
+ * <p>State is a set of {@code (value, vectorClock)} pairs. On each write, the
+ * local VC is bumped and any existing pair causally dominated by the new VC is
+ * dropped. On merge, the union is taken and any pair causally dominated by some
+ * other pair in the union is dropped. What survives are the "maximal elements
+ * of the partial order" — concurrent writes that nobody has yet seen and resolved.
+ *
+ * <p>This is the original Dynamo-paper semantics (2007). The shopping-cart
+ * use case: phone adds "socks" while disconnected, tablet adds "shirt" while
+ * disconnected — both pairs survive, the cart SDK applies a domain rule
+ * (union for carts), writes back a single value with a VC that dominates both,
+ * and the conflict is resolved.
+ *
+ * <p>Note: AWS DynamoDB the product hides this and uses LWW by default.
+ * "DynamoDB-style consistency" usually refers to the original paper, not the AWS service.
+ */
+public final class MVRegister {
+
+    private static final byte FORMAT_VERSION = 1;
+
+    /**
+     * One concurrent value, stamped with the vector clock under which it was written.
+     *
+     * @param value the value bytes
+     * @param vc    vector clock at the moment of the write
+     */
+    public record Entry(byte[] value, VectorClock vc) { }
+
+    private final String localNodeId;
+    private final VectorClock localVc;
+    private List<Entry> entries;
+
+    /**
+     * Create an empty multi-value register owned by the given node.
+     *
+     * @param localNodeId stable node identity
+     */
+    public MVRegister(final String localNodeId) {
+        this.localNodeId = Objects.requireNonNull(localNodeId, "localNodeId");
+        this.localVc = new VectorClock();
+        this.entries = new ArrayList<>();
+    }
+
+    private MVRegister(
+            final String localNodeId,
+            final VectorClock localVc,
+            final List<Entry> entries) {
+        this.localNodeId = Objects.requireNonNull(localNodeId, "localNodeId");
+        this.localVc = localVc;
+        this.entries = entries;
+    }
+
+    /**
+     * Write a new value. Bumps the local VC, drops everything it dominates,
+     * and stores the new (value, VC) pair.
+     *
+     * @param newValue value to write
+     */
+    public synchronized void set(final byte[] newValue) {
+        localVc.increment(localNodeId);
+        VectorClock writeVc = localVc.copy();
+
+        List<Entry> kept = new ArrayList<>();
+        for (Entry e : entries) {
+            // Drop entries strictly dominated by the new write.
+            if (e.vc.compare(writeVc) != VectorClock.Ordering.BEFORE) {
+                kept.add(e);
+            }
+        }
+        kept.add(new Entry(newValue, writeVc));
+        this.entries = kept;
+    }
+
+    /**
+     * @return all currently surviving values (size 1 in the absence of conflict, &gt;1 otherwise)
+     */
+    public synchronized List<byte[]> values() {
+        List<byte[]> out = new ArrayList<>(entries.size());
+        for (Entry e : entries) {
+            out.add(e.value);
+        }
+        return out;
+    }
+
+    /**
+     * @return read-only view of the underlying (value, VC) pairs
+     */
+    public synchronized List<Entry> entries() {
+        return Collections.unmodifiableList(new ArrayList<>(entries));
+    }
+
+    /**
+     * Merge another MVRegister into this one (in place).
+     * Keeps the maximal pairs of the combined partial order.
+     *
+     * @param other another MVRegister
+     */
+    public synchronized void merge(final MVRegister other) {
+        // Bring our local VC up to date so subsequent writes dominate everything we've seen.
+        localVc.mergeMax(other.localVc);
+
+        // Combine pairs and drop those dominated by any other.
+        List<Entry> combined = new ArrayList<>(this.entries);
+        combined.addAll(other.entries());
+
+        List<Entry> kept = new ArrayList<>();
+        for (int i = 0; i < combined.size(); i++) {
+            Entry candidate = combined.get(i);
+            boolean dominated = false;
+            for (int j = 0; j < combined.size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+                if (candidate.vc.compare(combined.get(j).vc) == VectorClock.Ordering.BEFORE) {
+                    dominated = true;
+                    break;
+                }
+            }
+            if (!dominated && !containsSamePair(kept, candidate)) {
+                kept.add(candidate);
+            }
+        }
+        this.entries = kept;
+    }
+
+    /** Avoid duplicate-VC duplicates in the survivor set after a merge of identical states. */
+    private static boolean containsSamePair(final List<Entry> list, final Entry e) {
+        for (Entry other : list) {
+            if (other.vc.equals(e.vc) && java.util.Arrays.equals(other.value, e.value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Serialize state.
+     *
+     * <p>Format: {@code [version:byte] [vcLen:int] [vcBytes] [entryCount:int]
+     *               N x ([valLen:int] [valBytes] [vcLen:int] [vcBytes])}
+     *
+     * @return wire-format bytes
+     */
+    public synchronized byte[] serialize() {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeByte(FORMAT_VERSION);
+            byte[] vcBytes = localVc.serialize();
+            out.writeInt(vcBytes.length);
+            out.write(vcBytes);
+            out.writeInt(entries.size());
+            for (Entry e : entries) {
+                out.writeInt(e.value.length);
+                out.write(e.value);
+                byte[] eVcBytes = e.vc.serialize();
+                out.writeInt(eVcBytes.length);
+                out.write(eVcBytes);
+            }
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Reconstruct from serialized form.
+     *
+     * @param localNodeId node identity
+     * @param bytes       output of {@link #serialize()}
+     * @return reconstructed MVRegister
+     */
+    public static MVRegister deserialize(final String localNodeId, final byte[] bytes) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
+            byte version = in.readByte();
+            if (version != FORMAT_VERSION) {
+                throw new IllegalStateException(
+                        "Unknown MVRegister format version: " + version);
+            }
+            int vcLen = in.readInt();
+            byte[] vcBytes = in.readNBytes(vcLen);
+            VectorClock vc = VectorClock.deserialize(vcBytes);
+
+            int count = in.readInt();
+            List<Entry> entryList = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                int valLen = in.readInt();
+                byte[] val = in.readNBytes(valLen);
+                int eVcLen = in.readInt();
+                byte[] eVcBytes = in.readNBytes(eVcLen);
+                entryList.add(new Entry(val, VectorClock.deserialize(eVcBytes)));
+            }
+            return new MVRegister(localNodeId, vc, entryList);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * @return number of distinct concurrent values currently held
+     */
+    public int size() {
+        return entries.size();
+    }
+
+    @Override
+    public synchronized String toString() {
+        Set<String> vals = new HashSet<>();
+        for (Entry e : entries) {
+            vals.add(new String(e.value));
+        }
+        return "MVRegister{node=" + localNodeId + ", localVc=" + localVc + ", values=" + vals + "}";
+    }
+}

--- a/kiradb-crdt/src/main/java/io/kiradb/crdt/ORSet.java
+++ b/kiradb-crdt/src/main/java/io/kiradb/crdt/ORSet.java
@@ -1,0 +1,232 @@
+package io.kiradb.crdt;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Observed-Remove Set — adds and removes can both happen concurrently on
+ * different replicas without losing data, and concurrent re-adds always survive
+ * concurrent removes.
+ *
+ * <h2>The trick: tag every add with a unique id</h2>
+ * Each {@code add(x)} produces a fresh {@link UUID}. The element is "in the set"
+ * iff at least one of its add tags has not yet been removed.
+ *
+ * <p>{@code remove(x)} only kills the tags it has <i>currently observed</i>.
+ * If another replica concurrently performs {@code add(x)} with a brand-new tag
+ * the remover never saw, the element survives — which matches user intent in
+ * shopping carts and presence sets ("better resurrect than lose").
+ *
+ * <h2>Known limitation</h2>
+ * Tombstones (removed tags) accumulate over time. Production systems use
+ * causal-stability-based GC; for Phase 6 we accept unbounded tombstone growth
+ * as a documented limitation.
+ */
+public final class ORSet {
+
+    private static final byte FORMAT_VERSION = 1;
+
+    /** element -> set of live add-tags. Empty value-set means the element is currently absent. */
+    private final ConcurrentMap<String, Set<UUID>> liveAdds;
+
+    /** All add-tags that have been removed. Required to suppress already-deleted tags arriving via merge. */
+    private final Set<UUID> tombstones;
+
+    /**
+     * Create an empty ORSet.
+     */
+    public ORSet() {
+        this.liveAdds = new ConcurrentHashMap<>();
+        this.tombstones = ConcurrentHashMap.newKeySet();
+    }
+
+    private ORSet(final Map<String, Set<UUID>> initialAdds, final Set<UUID> initialTombs) {
+        this.liveAdds = new ConcurrentHashMap<>();
+        for (var e : initialAdds.entrySet()) {
+            this.liveAdds.put(e.getKey(), ConcurrentHashMap.newKeySet());
+            this.liveAdds.get(e.getKey()).addAll(e.getValue());
+        }
+        this.tombstones = ConcurrentHashMap.newKeySet();
+        this.tombstones.addAll(initialTombs);
+    }
+
+    /**
+     * Add an element to the set (always succeeds; produces a fresh add-tag).
+     *
+     * @param element element to add
+     */
+    public void add(final String element) {
+        Objects.requireNonNull(element, "element");
+        UUID tag = UUID.randomUUID();
+        liveAdds.computeIfAbsent(element, k -> ConcurrentHashMap.newKeySet()).add(tag);
+    }
+
+    /**
+     * Remove an element from the set. Kills only the add-tags currently observed
+     * locally; concurrent adds elsewhere will survive.
+     *
+     * @param element element to remove
+     * @return true if any tag was observed and removed
+     */
+    public synchronized boolean remove(final String element) {
+        Set<UUID> tags = liveAdds.remove(element);
+        if (tags == null || tags.isEmpty()) {
+            return false;
+        }
+        tombstones.addAll(tags);
+        return true;
+    }
+
+    /**
+     * @param element element to test
+     * @return true if the element has at least one live (non-tombstoned) add-tag
+     */
+    public boolean contains(final String element) {
+        Set<UUID> tags = liveAdds.get(element);
+        return tags != null && !tags.isEmpty();
+    }
+
+    /**
+     * @return snapshot of all elements currently in the set
+     */
+    public Set<String> elements() {
+        Set<String> out = new HashSet<>();
+        for (var entry : liveAdds.entrySet()) {
+            if (!entry.getValue().isEmpty()) {
+                out.add(entry.getKey());
+            }
+        }
+        return Collections.unmodifiableSet(out);
+    }
+
+    /**
+     * @return number of distinct elements currently in the set
+     */
+    public int size() {
+        return elements().size();
+    }
+
+    /**
+     * Merge another ORSet into this one (in place).
+     *
+     * <p>Algorithm:
+     * <ol>
+     *   <li>Union of tombstones — once a tag is removed anywhere, it stays removed.</li>
+     *   <li>Union of add-tags per element, then strip out any tag in the merged tombstone set.</li>
+     * </ol>
+     * Crucially this means an add-tag the local node never saw, but which the remote
+     * has tombstoned, becomes correctly absent — and an add-tag generated <i>after</i>
+     * a concurrent remove (different tag, never tombstoned) survives.
+     *
+     * @param other another ORSet
+     */
+    public synchronized void merge(final ORSet other) {
+        // Union tombstones first — these are authoritative deletions.
+        tombstones.addAll(other.tombstones);
+
+        // Union live adds, suppressing anything in the merged tombstone set.
+        for (var entry : other.liveAdds.entrySet()) {
+            String element = entry.getKey();
+            Set<UUID> incomingTags = entry.getValue();
+            Set<UUID> localTags = liveAdds.computeIfAbsent(
+                    element, k -> ConcurrentHashMap.newKeySet());
+            for (UUID t : incomingTags) {
+                if (!tombstones.contains(t)) {
+                    localTags.add(t);
+                }
+            }
+        }
+
+        // Sweep: strip tombstoned tags out of local liveAdds, drop empty entries.
+        for (var entry : liveAdds.entrySet()) {
+            entry.getValue().removeAll(tombstones);
+        }
+        liveAdds.entrySet().removeIf(e -> e.getValue().isEmpty());
+    }
+
+    /**
+     * Serialize state.
+     *
+     * <p>Format: {@code [version:byte] [elementCount:int]
+     *           N x ([utf:String] [tagCount:int] N x [uuidMsb:long] [uuidLsb:long])
+     *           [tombstoneCount:int] N x ([uuidMsb:long] [uuidLsb:long])}
+     *
+     * @return wire-format bytes
+     */
+    public synchronized byte[] serialize() {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeByte(FORMAT_VERSION);
+            out.writeInt(liveAdds.size());
+            for (var entry : liveAdds.entrySet()) {
+                out.writeUTF(entry.getKey());
+                Set<UUID> tags = entry.getValue();
+                out.writeInt(tags.size());
+                for (UUID t : tags) {
+                    out.writeLong(t.getMostSignificantBits());
+                    out.writeLong(t.getLeastSignificantBits());
+                }
+            }
+            out.writeInt(tombstones.size());
+            for (UUID t : tombstones) {
+                out.writeLong(t.getMostSignificantBits());
+                out.writeLong(t.getLeastSignificantBits());
+            }
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Reconstruct from serialized form.
+     *
+     * @param bytes output of {@link #serialize()}
+     * @return reconstructed ORSet
+     */
+    public static ORSet deserialize(final byte[] bytes) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
+            byte version = in.readByte();
+            if (version != FORMAT_VERSION) {
+                throw new IllegalStateException(
+                        "Unknown ORSet format version: " + version);
+            }
+            int elementCount = in.readInt();
+            Map<String, Set<UUID>> adds = new HashMap<>(elementCount);
+            for (int i = 0; i < elementCount; i++) {
+                String element = in.readUTF();
+                int tagCount = in.readInt();
+                Set<UUID> tags = new HashSet<>(tagCount);
+                for (int j = 0; j < tagCount; j++) {
+                    long msb = in.readLong();
+                    long lsb = in.readLong();
+                    tags.add(new UUID(msb, lsb));
+                }
+                adds.put(element, tags);
+            }
+            int tombCount = in.readInt();
+            Set<UUID> tombs = new HashSet<>(tombCount);
+            for (int i = 0; i < tombCount; i++) {
+                long msb = in.readLong();
+                long lsb = in.readLong();
+                tombs.add(new UUID(msb, lsb));
+            }
+            return new ORSet(adds, tombs);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/kiradb-crdt/src/main/java/io/kiradb/crdt/PNCounter.java
+++ b/kiradb-crdt/src/main/java/io/kiradb/crdt/PNCounter.java
@@ -1,0 +1,150 @@
+package io.kiradb.crdt;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * Positive-Negative counter — supports both increments and decrements.
+ *
+ * <p>Built from two {@link GCounter}s: one for additions ({@code P}), one for
+ * subtractions ({@code N}). Value is {@code P.value() - N.value()}.
+ *
+ * <h2>Why decompose into two grow-only counters?</h2>
+ * GCounter is provably conflict-free. A single counter that allows both
+ * increment and decrement is not — concurrent {@code +1} and {@code -1} from
+ * different replicas would not converge under max-merge. By restricting each
+ * underlying counter to monotonic growth, the merge math stays trivially safe.
+ * This "decompose what you can't do into two things you can do" pattern
+ * recurs throughout CRDT design.
+ */
+public final class PNCounter {
+
+    private static final byte FORMAT_VERSION = 1;
+
+    private final String localNodeId;
+    private final GCounter positive;
+    private final GCounter negative;
+
+    /**
+     * Create a fresh PNCounter owned by the given node.
+     *
+     * @param localNodeId stable node identity
+     */
+    public PNCounter(final String localNodeId) {
+        this.localNodeId = Objects.requireNonNull(localNodeId, "localNodeId");
+        this.positive = new GCounter(localNodeId);
+        this.negative = new GCounter(localNodeId);
+    }
+
+    private PNCounter(final String localNodeId, final GCounter p, final GCounter n) {
+        this.localNodeId = Objects.requireNonNull(localNodeId, "localNodeId");
+        this.positive = p;
+        this.negative = n;
+    }
+
+    /**
+     * Apply a signed delta. Positive routes to the P counter; negative to N.
+     * Zero is a no-op.
+     *
+     * @param delta signed change to apply
+     */
+    public void add(final long delta) {
+        if (delta > 0) {
+            positive.increment(delta);
+        } else if (delta < 0) {
+            negative.increment(-delta);
+        }
+    }
+
+    /**
+     * Increment by 1.
+     */
+    public void increment() {
+        positive.increment();
+    }
+
+    /**
+     * Decrement by 1.
+     */
+    public void decrement() {
+        negative.increment();
+    }
+
+    /**
+     * @return current signed value: {@code P - N}
+     */
+    public long value() {
+        return positive.value() - negative.value();
+    }
+
+    /**
+     * Merge another PNCounter into this one (in place).
+     *
+     * @param other another PNCounter
+     */
+    public synchronized void merge(final PNCounter other) {
+        positive.merge(other.positive);
+        negative.merge(other.negative);
+    }
+
+    /**
+     * Serialize state. Format: {@code [version:byte] [P bytes len:int] [P bytes] [N bytes len:int] [N bytes]}.
+     *
+     * @return wire-format bytes
+     */
+    public byte[] serialize() {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeByte(FORMAT_VERSION);
+            byte[] pBytes = positive.serialize();
+            byte[] nBytes = negative.serialize();
+            out.writeInt(pBytes.length);
+            out.write(pBytes);
+            out.writeInt(nBytes.length);
+            out.write(nBytes);
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Reconstruct from serialized form.
+     *
+     * @param localNodeId node identity to bind this instance to
+     * @param bytes       output of {@link #serialize()}
+     * @return reconstructed PNCounter
+     */
+    public static PNCounter deserialize(final String localNodeId, final byte[] bytes) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
+            byte version = in.readByte();
+            if (version != FORMAT_VERSION) {
+                throw new IllegalStateException(
+                        "Unknown PNCounter format version: " + version);
+            }
+            int pLen = in.readInt();
+            byte[] pBytes = in.readNBytes(pLen);
+            int nLen = in.readInt();
+            byte[] nBytes = in.readNBytes(nLen);
+            return new PNCounter(
+                    localNodeId,
+                    GCounter.deserialize(localNodeId, pBytes),
+                    GCounter.deserialize(localNodeId, nBytes));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "PNCounter{node=" + localNodeId
+                + ", value=" + value()
+                + ", P=" + positive.value()
+                + ", N=" + negative.value() + "}";
+    }
+}

--- a/kiradb-crdt/src/main/java/io/kiradb/crdt/VectorClock.java
+++ b/kiradb-crdt/src/main/java/io/kiradb/crdt/VectorClock.java
@@ -1,0 +1,231 @@
+package io.kiradb.crdt;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Vector clock — captures causality between events without a wall clock.
+ *
+ * <p>State: a map from node id to a per-node monotonic counter.
+ * Three update rules:
+ * <ol>
+ *   <li>Local event on node N → {@code VC[N]++}</li>
+ *   <li>Send message from N → attach a copy of VC</li>
+ *   <li>Receive message with VC' on N → element-wise max with VC, then {@code VC[N]++}</li>
+ * </ol>
+ *
+ * <h2>Comparing two vector clocks</h2>
+ * <ul>
+ *   <li><b>BEFORE</b>: A ≤ B on every key, A &lt; B on at least one — A causally precedes B.</li>
+ *   <li><b>AFTER</b>: B ≤ A on every key, B &lt; A on at least one — B causally precedes A.</li>
+ *   <li><b>EQUAL</b>: same on every key.</li>
+ *   <li><b>CONCURRENT</b>: neither dominates — events with no causal relationship.</li>
+ * </ul>
+ *
+ * <p>This is the underpinning of {@link MVRegister} and other causality-aware CRDTs.
+ *
+ * <h2>Invariant: only the owning node may increment its own slot</h2>
+ * Violating this (e.g., letting clients bump arbitrary slots) caused the famous
+ * Riak "vector clock explosion" bug — clocks ballooned to millions of entries.
+ * Increment authority must be enforced server-side.
+ */
+public final class VectorClock {
+
+    private static final byte FORMAT_VERSION = 1;
+
+    /**
+     * Pairwise causal ordering between two vector clocks.
+     */
+    public enum Ordering {
+        /** This clock causally precedes the other. */
+        BEFORE,
+        /** This clock causally follows the other. */
+        AFTER,
+        /** Both clocks are identical. */
+        EQUAL,
+        /** Neither dominates — events are concurrent. */
+        CONCURRENT
+    }
+
+    private final Map<String, Long> clock;
+
+    /**
+     * Create an empty vector clock.
+     */
+    public VectorClock() {
+        this.clock = new HashMap<>();
+    }
+
+    private VectorClock(final Map<String, Long> initial) {
+        this.clock = new HashMap<>(initial);
+    }
+
+    /**
+     * Create a vector clock from a snapshot map (deep copy).
+     *
+     * @param snapshot raw {@code nodeId -> counter} map
+     * @return new vector clock holding a copy of the given state
+     */
+    public static VectorClock of(final Map<String, Long> snapshot) {
+        return new VectorClock(snapshot);
+    }
+
+    /**
+     * Increment the given node's slot by 1. Used when {@code nodeId} performs a local event.
+     *
+     * @param nodeId node performing the event
+     */
+    public synchronized void increment(final String nodeId) {
+        Objects.requireNonNull(nodeId, "nodeId");
+        clock.merge(nodeId, 1L, Long::sum);
+    }
+
+    /**
+     * @param nodeId node identity to inspect
+     * @return current value for the given node, or 0 if absent
+     */
+    public long get(final String nodeId) {
+        return clock.getOrDefault(nodeId, 0L);
+    }
+
+    /**
+     * Element-wise max merge in place. Equivalent to receiving a remote VC and
+     * taking the max with the local VC. Does NOT increment afterwards — callers
+     * doing receive-then-local-event must call {@link #increment(String)} themselves.
+     *
+     * @param other vector clock to merge in
+     */
+    public synchronized void mergeMax(final VectorClock other) {
+        for (var entry : other.clock.entrySet()) {
+            clock.merge(entry.getKey(), entry.getValue(), Math::max);
+        }
+    }
+
+    /**
+     * @return defensive deep copy
+     */
+    public synchronized VectorClock copy() {
+        return new VectorClock(clock);
+    }
+
+    /**
+     * @return read-only snapshot of the underlying map
+     */
+    public Map<String, Long> snapshot() {
+        return Collections.unmodifiableMap(new HashMap<>(clock));
+    }
+
+    /**
+     * Compare two vector clocks for causal ordering.
+     *
+     * @param other other clock
+     * @return ordering classification
+     */
+    public Ordering compare(final VectorClock other) {
+        boolean thisLessOrEqual = true;  // every slot of this <= other
+        boolean otherLessOrEqual = true; // every slot of other <= this
+
+        Set<String> nodes = new HashSet<>();
+        nodes.addAll(this.clock.keySet());
+        nodes.addAll(other.clock.keySet());
+
+        for (String node : nodes) {
+            long a = this.get(node);
+            long b = other.get(node);
+            if (a > b) {
+                thisLessOrEqual = false;
+            }
+            if (a < b) {
+                otherLessOrEqual = false;
+            }
+        }
+
+        if (thisLessOrEqual && otherLessOrEqual) {
+            return Ordering.EQUAL;
+        }
+        if (thisLessOrEqual) {
+            return Ordering.BEFORE;
+        }
+        if (otherLessOrEqual) {
+            return Ordering.AFTER;
+        }
+        return Ordering.CONCURRENT;
+    }
+
+    /**
+     * Serialize this clock. Format: {@code [version:byte] [count:int] N x ([utf:String] [val:long])}.
+     *
+     * @return wire-format bytes
+     */
+    public byte[] serialize() {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeByte(FORMAT_VERSION);
+            out.writeInt(clock.size());
+            for (var entry : clock.entrySet()) {
+                out.writeUTF(entry.getKey());
+                out.writeLong(entry.getValue());
+            }
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Reconstruct from serialized form.
+     *
+     * @param bytes output of {@link #serialize()}
+     * @return reconstructed vector clock
+     */
+    public static VectorClock deserialize(final byte[] bytes) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
+            byte version = in.readByte();
+            if (version != FORMAT_VERSION) {
+                throw new IllegalStateException(
+                        "Unknown VectorClock format version: " + version);
+            }
+            int count = in.readInt();
+            Map<String, Long> initial = new HashMap<>(count);
+            for (int i = 0; i < count; i++) {
+                String node = in.readUTF();
+                long val = in.readLong();
+                initial.put(node, val);
+            }
+            return new VectorClock(initial);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof VectorClock other)) {
+            return false;
+        }
+        return clock.equals(other.clock);
+    }
+
+    @Override
+    public int hashCode() {
+        return clock.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "VC" + clock;
+    }
+}

--- a/kiradb-crdt/src/test/java/io/kiradb/crdt/CrdtStoreTest.java
+++ b/kiradb-crdt/src/test/java/io/kiradb/crdt/CrdtStoreTest.java
@@ -1,0 +1,160 @@
+package io.kiradb.crdt;
+
+import io.kiradb.core.storage.StorageEngine;
+import io.kiradb.core.storage.StorageEntry;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class CrdtStoreTest {
+
+    @Test
+    void gCounterIncrementPersistsAndReloads() {
+        FakeStorage storage = new FakeStorage();
+        CrdtStore s1 = new CrdtStore(storage, "node1");
+        s1.gCounterIncrement("votes", 5);
+        s1.gCounterIncrement("votes", 3);
+        assertEquals(8, s1.gCounterValue("votes"));
+
+        // New CrdtStore over the same storage — must reload state.
+        CrdtStore s2 = new CrdtStore(storage, "node1");
+        assertEquals(8, s2.gCounterValue("votes"));
+    }
+
+    @Test
+    void mergeGCounterAcceptsRemoteState() {
+        FakeStorage storage = new FakeStorage();
+        CrdtStore local = new CrdtStore(storage, "local");
+        local.gCounterIncrement("votes", 4);
+
+        // A peer's serialized counter (from a different node).
+        GCounter remote = new GCounter("peer");
+        remote.increment(7);
+        local.mergeGCounter("votes", remote.serialize());
+
+        assertEquals(11, local.gCounterValue("votes"));
+
+        // And the merge persisted: a fresh store sees the merged total.
+        CrdtStore reload = new CrdtStore(storage, "local");
+        assertEquals(11, reload.gCounterValue("votes"));
+    }
+
+    @Test
+    void pnCounterRoundTrip() {
+        FakeStorage storage = new FakeStorage();
+        CrdtStore s = new CrdtStore(storage, "n");
+        s.pnCounterAdd("balance", 100);
+        s.pnCounterAdd("balance", -30);
+        assertEquals(70, s.pnCounterValue("balance"));
+
+        CrdtStore reload = new CrdtStore(storage, "n");
+        assertEquals(70, reload.pnCounterValue("balance"));
+    }
+
+    @Test
+    void lwwRoundTrip() {
+        FakeStorage storage = new FakeStorage();
+        CrdtStore s = new CrdtStore(storage, "n");
+        s.lwwSet("flag.dark-mode", "true".getBytes(StandardCharsets.UTF_8));
+        assertArrayEquals("true".getBytes(StandardCharsets.UTF_8), s.lwwGet("flag.dark-mode"));
+
+        CrdtStore reload = new CrdtStore(storage, "n");
+        assertArrayEquals("true".getBytes(StandardCharsets.UTF_8),
+                reload.lwwGet("flag.dark-mode"));
+    }
+
+    @Test
+    void orSetRoundTrip() {
+        FakeStorage storage = new FakeStorage();
+        CrdtStore s = new CrdtStore(storage, "n");
+        s.orSetAdd("online-users", "alice");
+        s.orSetAdd("online-users", "bob");
+        s.orSetRemove("online-users", "alice");
+
+        ORSet set = s.orSet("online-users");
+        assertTrue(set.contains("bob"));
+        assertEquals(1, set.size());
+
+        CrdtStore reload = new CrdtStore(storage, "n");
+        ORSet reloaded = reload.orSet("online-users");
+        assertEquals(set.elements(), reloaded.elements());
+    }
+
+    @Test
+    void instancesAreCachedPerName() {
+        FakeStorage storage = new FakeStorage();
+        CrdtStore s = new CrdtStore(storage, "n");
+        GCounter first = s.gCounter("c");
+        GCounter again = s.gCounter("c");
+        assertNotNull(first);
+        assertEquals(System.identityHashCode(first), System.identityHashCode(again));
+    }
+
+    /** Minimal in-memory StorageEngine — just put/get for CRDT bytes. */
+    private static final class FakeStorage implements StorageEngine {
+        private final ConcurrentHashMap<String, byte[]> store = new ConcurrentHashMap<>();
+
+        private static String k(final byte[] key) {
+            return new String(key, StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public void put(final byte[] key, final byte[] value) {
+            store.put(k(key), value);
+        }
+
+        @Override
+        public void put(final byte[] key, final byte[] value, final long expiryMillis) {
+            store.put(k(key), value);
+        }
+
+        @Override
+        public Optional<byte[]> get(final byte[] key) {
+            return Optional.ofNullable(store.get(k(key)));
+        }
+
+        @Override
+        public boolean delete(final byte[] key) {
+            return store.remove(k(key)) != null;
+        }
+
+        @Override
+        public boolean exists(final byte[] key) {
+            return store.containsKey(k(key));
+        }
+
+        @Override
+        public long ttlMillis(final byte[] key) {
+            return store.containsKey(k(key)) ? -1 : -2;
+        }
+
+        @Override
+        public boolean expire(final byte[] key, final long expiryMillis) {
+            return false;
+        }
+
+        @Override
+        public Iterator<StorageEntry> scan(final byte[] startKey, final byte[] endKey) {
+            TreeMap<String, byte[]> sorted = new TreeMap<>(store);
+            return sorted.entrySet().stream()
+                    .map(e -> StorageEntry.live(
+                            e.getKey().getBytes(StandardCharsets.UTF_8), e.getValue()))
+                    .map(se -> (StorageEntry) se)
+                    .iterator();
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/kiradb-crdt/src/test/java/io/kiradb/crdt/GCounterTest.java
+++ b/kiradb-crdt/src/test/java/io/kiradb/crdt/GCounterTest.java
@@ -1,0 +1,127 @@
+package io.kiradb.crdt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class GCounterTest {
+
+    @Test
+    void incrementAndValue() {
+        GCounter c = new GCounter("a");
+        c.increment();
+        c.increment(5);
+        assertEquals(6, c.value());
+    }
+
+    @Test
+    void rejectsNonPositiveDelta() {
+        GCounter c = new GCounter("a");
+        assertThrows(IllegalArgumentException.class, () -> c.increment(0));
+        assertThrows(IllegalArgumentException.class, () -> c.increment(-1));
+    }
+
+    @Test
+    void mergeIsCommutative() {
+        GCounter a = new GCounter("a");
+        GCounter b = new GCounter("b");
+        a.increment(3);
+        b.increment(7);
+
+        GCounter ab = new GCounter("a");
+        ab.merge(a);
+        ab.merge(b);
+
+        GCounter ba = new GCounter("b");
+        ba.merge(b);
+        ba.merge(a);
+
+        assertEquals(10, ab.value());
+        assertEquals(10, ba.value());
+        assertEquals(ab.slotsSnapshot(), ba.slotsSnapshot());
+    }
+
+    @Test
+    void mergeIsIdempotent() {
+        GCounter a = new GCounter("a");
+        a.increment(4);
+        GCounter target = new GCounter("b");
+        target.merge(a);
+        target.merge(a);
+        target.merge(a);
+        assertEquals(4, target.value());
+    }
+
+    @Test
+    void mergeIsAssociative() {
+        GCounter a = new GCounter("a");
+        a.increment(1);
+        GCounter b = new GCounter("b");
+        b.increment(2);
+        GCounter c = new GCounter("c");
+        c.increment(4);
+
+        GCounter left = new GCounter("x");
+        left.merge(a);
+        left.merge(b);
+        left.merge(c);
+
+        GCounter right = new GCounter("y");
+        GCounter bc = new GCounter("y");
+        bc.merge(b);
+        bc.merge(c);
+        right.merge(a);
+        right.merge(bc);
+
+        assertEquals(7, left.value());
+        assertEquals(7, right.value());
+        assertEquals(left.slotsSnapshot(), right.slotsSnapshot());
+    }
+
+    @Test
+    void convergenceUnderShuffledArrival() {
+        // Three nodes, each makes some increments locally; all peers gossip
+        // to each other in arbitrary orders — every replica must converge.
+        GCounter a = new GCounter("a");
+        GCounter b = new GCounter("b");
+        GCounter c = new GCounter("c");
+        a.increment(2);
+        a.increment(3);
+        b.increment(7);
+        c.increment(1);
+        c.increment(1);
+
+        // Order 1: a <- b <- c
+        GCounter r1 = new GCounter("r1");
+        r1.merge(a); r1.merge(b); r1.merge(c);
+
+        // Order 2: c <- a <- b
+        GCounter r2 = new GCounter("r2");
+        r2.merge(c); r2.merge(a); r2.merge(b);
+
+        // Order 3: with duplicates
+        GCounter r3 = new GCounter("r3");
+        r3.merge(b); r3.merge(b); r3.merge(c); r3.merge(a); r3.merge(c);
+
+        assertEquals(14, r1.value());
+        assertEquals(14, r2.value());
+        assertEquals(14, r3.value());
+        assertEquals(r1.slotsSnapshot(), r2.slotsSnapshot());
+        assertEquals(r1.slotsSnapshot(), r3.slotsSnapshot());
+    }
+
+    @Test
+    void serializationRoundTrip() {
+        GCounter c = new GCounter("a");
+        c.increment(42);
+        GCounter peer = new GCounter("b");
+        peer.increment(7);
+        c.merge(peer);
+
+        byte[] bytes = c.serialize();
+        GCounter restored = GCounter.deserialize("a", bytes);
+        assertEquals(c.value(), restored.value());
+        assertEquals(c.slotsSnapshot(), restored.slotsSnapshot());
+    }
+}

--- a/kiradb-crdt/src/test/java/io/kiradb/crdt/LWWRegisterTest.java
+++ b/kiradb-crdt/src/test/java/io/kiradb/crdt/LWWRegisterTest.java
@@ -1,0 +1,79 @@
+package io.kiradb.crdt;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+final class LWWRegisterTest {
+
+    private static byte[] b(final String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void higherTimestampWins() {
+        LWWRegister a = new LWWRegister("a");
+        a.set(b("v1"), 100);
+
+        LWWRegister b = new LWWRegister("b");
+        b.set(b("v2"), 200);
+
+        a.merge(b);
+        assertArrayEquals(b("v2"), a.get());
+        assertEquals(200, a.timestamp());
+    }
+
+    @Test
+    void tieBrokenByLargerNodeId() {
+        LWWRegister a = new LWWRegister("a");
+        a.set(b("vA"), 100);
+
+        LWWRegister z = new LWWRegister("z");
+        z.set(b("vZ"), 100);
+
+        // Merge in both directions — both must converge to the same answer.
+        LWWRegister copyA = LWWRegister.deserialize("a", a.serialize());
+        copyA.merge(z);
+
+        LWWRegister copyZ = LWWRegister.deserialize("z", z.serialize());
+        copyZ.merge(a);
+
+        assertArrayEquals(b("vZ"), copyA.get());
+        assertArrayEquals(b("vZ"), copyZ.get());
+    }
+
+    @Test
+    void mergeIsIdempotentAndCommutative() {
+        LWWRegister a = new LWWRegister("a");
+        a.set(b("hello"), 50);
+        LWWRegister b = new LWWRegister("b");
+        b.set(b("world"), 99);
+
+        LWWRegister r1 = LWWRegister.deserialize("r1", new LWWRegister("r1").serialize());
+        r1.merge(a); r1.merge(b); r1.merge(b);
+
+        LWWRegister r2 = LWWRegister.deserialize("r2", new LWWRegister("r2").serialize());
+        r2.merge(b); r2.merge(a);
+
+        assertArrayEquals(r1.get(), r2.get());
+        assertEquals(r1.timestamp(), r2.timestamp());
+    }
+
+    @Test
+    void emptyRegisterReturnsNull() {
+        assertNull(new LWWRegister("a").get());
+    }
+
+    @Test
+    void serializationRoundTrip() {
+        LWWRegister r = new LWWRegister("a");
+        r.set(b("hi"), 42);
+        LWWRegister back = LWWRegister.deserialize("a", r.serialize());
+        assertArrayEquals(b("hi"), back.get());
+        assertEquals(42, back.timestamp());
+    }
+}

--- a/kiradb-crdt/src/test/java/io/kiradb/crdt/MVRegisterTest.java
+++ b/kiradb-crdt/src/test/java/io/kiradb/crdt/MVRegisterTest.java
@@ -1,0 +1,163 @@
+package io.kiradb.crdt;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class MVRegisterTest {
+
+    private static byte[] b(final String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static Set<String> stringValues(final MVRegister r) {
+        Set<String> out = new HashSet<>();
+        for (byte[] v : r.values()) {
+            out.add(new String(v, StandardCharsets.UTF_8));
+        }
+        return out;
+    }
+
+    @Test
+    void singleWriteSurfacesSingleValue() {
+        MVRegister r = new MVRegister("a");
+        r.set(b("hello"));
+        assertEquals(Set.of("hello"), stringValues(r));
+    }
+
+    @Test
+    void concurrentWritesBothSurvive() {
+        // Classic Dynamo shopping-cart story: A and B write independently,
+        // then sync. Both values must be visible.
+        MVRegister a = new MVRegister("A");
+        a.set(b("socks"));
+        MVRegister bReg = new MVRegister("B");
+        bReg.set(b("shirt"));
+
+        a.merge(bReg);
+        bReg.merge(a);
+
+        assertEquals(Set.of("socks", "shirt"), stringValues(a));
+        assertEquals(Set.of("socks", "shirt"), stringValues(bReg));
+    }
+
+    @Test
+    void laterCausalWriteSupersedesAllPriorConcurrent() {
+        // After both replicas know about both concurrent writes, the next
+        // write on either must dominate them, leaving a single value.
+        MVRegister a = new MVRegister("A");
+        a.set(b("v1"));
+        MVRegister b = new MVRegister("B");
+        b.set(b("v2"));
+
+        a.merge(b);  // a sees both writes
+        a.set(b("v3"));  // app resolves and writes new value
+
+        assertEquals(Set.of("v3"), stringValues(a));
+
+        // Now propagate to B
+        b.merge(a);
+        assertEquals(Set.of("v3"), stringValues(b));
+    }
+
+    @Test
+    void mergeIsIdempotentForConcurrentSet() {
+        MVRegister a = new MVRegister("A");
+        a.set(b("v1"));
+        MVRegister b = new MVRegister("B");
+        b.set(b("v2"));
+
+        MVRegister r = new MVRegister("R");
+        r.merge(a);
+        r.merge(b);
+        r.merge(a);  // duplicates must not change state
+        r.merge(b);
+
+        assertEquals(Set.of("v1", "v2"), stringValues(r));
+        assertEquals(2, r.size());
+    }
+
+    @Test
+    void convergenceUnderShuffledArrival() {
+        MVRegister a = new MVRegister("A");
+        a.set(b("a-only"));
+        MVRegister bReg = new MVRegister("B");
+        bReg.set(b("b-only"));
+        MVRegister c = new MVRegister("C");
+        c.set(b("c-only"));
+
+        MVRegister r1 = new MVRegister("R1");
+        r1.merge(a); r1.merge(bReg); r1.merge(c);
+
+        MVRegister r2 = new MVRegister("R2");
+        r2.merge(c); r2.merge(a); r2.merge(bReg);
+
+        MVRegister r3 = new MVRegister("R3");
+        r3.merge(bReg); r3.merge(a); r3.merge(c); r3.merge(a);
+
+        assertEquals(stringValues(r1), stringValues(r2));
+        assertEquals(stringValues(r1), stringValues(r3));
+        assertEquals(3, r1.size());
+    }
+
+    @Test
+    void serializationRoundTrip() {
+        MVRegister a = new MVRegister("A");
+        a.set(b("hi"));
+        MVRegister bReg = new MVRegister("B");
+        bReg.set(b("there"));
+        a.merge(bReg);
+
+        MVRegister back = MVRegister.deserialize("A", a.serialize());
+        assertEquals(stringValues(a), stringValues(back));
+    }
+
+    @Test
+    void mvRegisterHonestlyExposesConflictUnlikeLWW() {
+        // Same scenario, two contracts: LWW silently picks one; MV exposes both.
+        MVRegister mv = new MVRegister("A");
+        mv.set(b("important-edit-A"));
+        MVRegister mvB = new MVRegister("B");
+        mvB.set(b("important-edit-B"));
+        mv.merge(mvB);
+
+        Set<String> values = stringValues(mv);
+        assertEquals(2, values.size(), "MV must surface both concurrent edits");
+        assertTrue(values.contains("important-edit-A"));
+        assertTrue(values.contains("important-edit-B"));
+    }
+
+    @Test
+    void worked4StepDynamoExample() {
+        // Mirror the worked example from the teaching doc:
+        // A writes v1, B writes v2 (concurrent), they sync, A writes v3.
+        MVRegister a = new MVRegister("A");
+        a.set(b("v1"));
+        MVRegister b = new MVRegister("B");
+        b.set(b("v2"));
+
+        // sync: both surface both
+        a.merge(b);
+        b.merge(a);
+        assertEquals(2, a.size());
+        assertEquals(2, b.size());
+
+        // App on A resolves and writes v3 — this dominates everything A has seen
+        a.set(b("v3"));
+        assertEquals(Set.of("v3"), stringValues(a));
+
+        // Propagating back to B drops v1 and v2
+        b.merge(a);
+        assertEquals(Set.of("v3"), stringValues(b));
+
+        // Use list assertion to demonstrate values() returns one element here
+        List<byte[]> finalValues = b.values();
+        assertEquals(1, finalValues.size());
+    }
+}

--- a/kiradb-crdt/src/test/java/io/kiradb/crdt/ORSetTest.java
+++ b/kiradb-crdt/src/test/java/io/kiradb/crdt/ORSetTest.java
@@ -1,0 +1,121 @@
+package io.kiradb.crdt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class ORSetTest {
+
+    @Test
+    void addAndContains() {
+        ORSet s = new ORSet();
+        s.add("apple");
+        s.add("banana");
+        assertTrue(s.contains("apple"));
+        assertTrue(s.contains("banana"));
+        assertFalse(s.contains("cherry"));
+        assertEquals(2, s.size());
+    }
+
+    @Test
+    void removeKillsObservedTags() {
+        ORSet s = new ORSet();
+        s.add("apple");
+        s.remove("apple");
+        assertFalse(s.contains("apple"));
+        assertEquals(0, s.size());
+    }
+
+    @Test
+    void concurrentAddSurvivesConcurrentRemove() {
+        // The defining ORSet property:
+        //   A observes apple, then removes it.
+        //   B concurrently re-adds apple (with a fresh tag A never saw).
+        // After merge, apple must SURVIVE.
+        ORSet a = new ORSet();
+        a.add("apple");
+
+        ORSet b = new ORSet();
+        b.merge(a);              // b now observes the same add-tag
+
+        // A removes (kills the tag it has seen)
+        a.remove("apple");
+
+        // B concurrently re-adds (new tag, never tombstoned)
+        b.add("apple");
+
+        // Sync both directions
+        ORSet aThenB = deepCopy(a);
+        aThenB.merge(b);
+
+        ORSet bThenA = deepCopy(b);
+        bThenA.merge(a);
+
+        assertTrue(aThenB.contains("apple"));
+        assertTrue(bThenA.contains("apple"));
+        assertEquals(aThenB.elements(), bThenA.elements());
+    }
+
+    @Test
+    void removePropagatesAcrossReplicas() {
+        // Single add visible everywhere, then a remove anywhere — element
+        // disappears on every replica after a full merge round.
+        ORSet a = new ORSet();
+        a.add("apple");
+
+        ORSet b = new ORSet();
+        b.merge(a);
+
+        a.remove("apple");
+
+        b.merge(a);
+        assertFalse(b.contains("apple"));
+    }
+
+    @Test
+    void mergeIsCommutativeAndIdempotent() {
+        ORSet a = new ORSet();
+        a.add("x");
+        a.add("y");
+        ORSet b = new ORSet();
+        b.add("y");
+        b.add("z");
+
+        ORSet ab = new ORSet();
+        ab.merge(a); ab.merge(b);
+        ab.merge(a); // idempotent
+
+        ORSet ba = new ORSet();
+        ba.merge(b); ba.merge(a);
+
+        assertEquals(Set.of("x", "y", "z"), ab.elements());
+        assertEquals(ab.elements(), ba.elements());
+    }
+
+    @Test
+    void serializationPreservesAddsAndTombstones() {
+        ORSet s = new ORSet();
+        s.add("alpha");
+        s.add("beta");
+        s.remove("beta");
+
+        ORSet restored = ORSet.deserialize(s.serialize());
+        assertEquals(s.elements(), restored.elements());
+
+        // Also: a remote re-add of beta must still work via the original tombstones.
+        // Bring an external "beta" add and merge — should NOT come back if the
+        // remote add carries one of our tombstoned tags. Test the round-trip
+        // is byte-stable instead.
+        byte[] first = s.serialize();
+        byte[] second = ORSet.deserialize(first).serialize();
+        assertEquals(first.length, second.length);
+    }
+
+    private static ORSet deepCopy(final ORSet s) {
+        return ORSet.deserialize(s.serialize());
+    }
+}

--- a/kiradb-crdt/src/test/java/io/kiradb/crdt/PNCounterTest.java
+++ b/kiradb-crdt/src/test/java/io/kiradb/crdt/PNCounterTest.java
@@ -1,0 +1,51 @@
+package io.kiradb.crdt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class PNCounterTest {
+
+    @Test
+    void supportsBothDirections() {
+        PNCounter c = new PNCounter("a");
+        c.increment();
+        c.increment();
+        c.decrement();
+        c.add(5);
+        c.add(-2);
+        assertEquals(4, c.value());
+    }
+
+    @Test
+    void mergeIsCommutativeAndIdempotent() {
+        PNCounter a = new PNCounter("a");
+        PNCounter b = new PNCounter("b");
+        a.add(10);
+        a.add(-3);
+        b.add(7);
+        b.add(-1);
+
+        PNCounter ab = new PNCounter("ab");
+        ab.merge(a);
+        ab.merge(b);
+        ab.merge(b);  // idempotent
+
+        PNCounter ba = new PNCounter("ba");
+        ba.merge(b);
+        ba.merge(a);
+
+        assertEquals(13, ab.value());
+        assertEquals(13, ba.value());
+    }
+
+    @Test
+    void serializationRoundTrip() {
+        PNCounter c = new PNCounter("a");
+        c.add(15);
+        c.add(-4);
+        byte[] bytes = c.serialize();
+        PNCounter restored = PNCounter.deserialize("a", bytes);
+        assertEquals(11, restored.value());
+    }
+}

--- a/kiradb-crdt/src/test/java/io/kiradb/crdt/VectorClockTest.java
+++ b/kiradb-crdt/src/test/java/io/kiradb/crdt/VectorClockTest.java
@@ -1,0 +1,81 @@
+package io.kiradb.crdt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class VectorClockTest {
+
+    @Test
+    void emptyClocksAreEqual() {
+        assertEquals(VectorClock.Ordering.EQUAL, new VectorClock().compare(new VectorClock()));
+    }
+
+    @Test
+    void sameSlotIncrementIsBefore() {
+        VectorClock a = new VectorClock();
+        a.increment("n1");
+        VectorClock b = a.copy();
+        b.increment("n1");
+        assertEquals(VectorClock.Ordering.BEFORE, a.compare(b));
+        assertEquals(VectorClock.Ordering.AFTER, b.compare(a));
+    }
+
+    @Test
+    void differentSlotsAreConcurrent() {
+        VectorClock a = new VectorClock();
+        a.increment("n1");
+        VectorClock b = new VectorClock();
+        b.increment("n2");
+        assertEquals(VectorClock.Ordering.CONCURRENT, a.compare(b));
+        assertEquals(VectorClock.Ordering.CONCURRENT, b.compare(a));
+    }
+
+    @Test
+    void mergeMaxThenIncrementProducesAfter() {
+        // The full Lamport receive rule: take element-wise max, then bump own slot.
+        VectorClock a = new VectorClock();
+        a.increment("n1");                // {n1:1}
+        VectorClock b = new VectorClock();
+        b.increment("n2");                // {n2:1}
+
+        b.mergeMax(a);                    // {n1:1, n2:1}
+        b.increment("n2");                // {n1:1, n2:2}
+
+        assertEquals(VectorClock.Ordering.AFTER, b.compare(a));
+    }
+
+    @Test
+    void worked3NodeExample() {
+        // From CLAUDE.md teaching example: A writes, B writes, B receives A.
+        VectorClock a = new VectorClock();
+        a.increment("A");                 // A's clock after local write
+        VectorClock writeAvc = a.copy();  // {A:1}
+
+        VectorClock b = new VectorClock();
+        b.increment("B");                 // B's clock after concurrent write
+        VectorClock writeBvc = b.copy();  // {B:1}
+
+        // Concurrent
+        assertEquals(VectorClock.Ordering.CONCURRENT, writeAvc.compare(writeBvc));
+
+        // B then receives A's message and does another local event
+        b.mergeMax(writeAvc);             // {A:1, B:1}
+        b.increment("B");                 // {A:1, B:2}
+
+        // B's new clock is AFTER both prior writes
+        assertEquals(VectorClock.Ordering.AFTER, b.compare(writeAvc));
+        assertEquals(VectorClock.Ordering.AFTER, b.compare(writeBvc));
+    }
+
+    @Test
+    void serializationRoundTrip() {
+        VectorClock vc = new VectorClock();
+        vc.increment("a");
+        vc.increment("a");
+        vc.increment("b");
+        VectorClock restored = VectorClock.deserialize(vc.serialize());
+        assertEquals(VectorClock.Ordering.EQUAL, vc.compare(restored));
+        assertEquals(vc, restored);
+    }
+}

--- a/kiradb-server/src/main/java/io/kiradb/server/KiraDBServer.java
+++ b/kiradb-server/src/main/java/io/kiradb/server/KiraDBServer.java
@@ -7,6 +7,7 @@ import io.kiradb.core.storage.StorageEngine;
 import io.kiradb.core.storage.lsm.LsmStorageEngine;
 import io.kiradb.core.storage.tier.MemCache;
 import io.kiradb.core.storage.tier.TieredStorageEngine;
+import io.kiradb.crdt.CrdtStore;
 import io.kiradb.server.command.CommandRouter;
 import io.kiradb.server.resp3.Resp3Decoder;
 import io.kiradb.server.resp3.Resp3Encoder;
@@ -50,6 +51,25 @@ public final class KiraDBServer {
     }
 
     /**
+     * Resolve a stable node identity for CRDT slot ownership.
+     *
+     * <p>Priority: {@code -Dkiradb.node.id=…} → hostname → {@code "node"}.
+     * NodeId stability across restarts is critical: a drifting id splits one
+     * logical node into two and would double counters / resurrect set elements.
+     */
+    private static String resolveNodeId() {
+        String prop = System.getProperty("kiradb.node.id");
+        if (prop != null && !prop.isBlank()) {
+            return prop;
+        }
+        try {
+            return java.net.InetAddress.getLocalHost().getHostName();
+        } catch (java.net.UnknownHostException e) {
+            return "node";
+        }
+    }
+
+    /**
      * Main entry point.
      *
      * @param args command-line arguments (unused for now)
@@ -73,7 +93,11 @@ public final class KiraDBServer {
             Runtime.getRuntime().addShutdownHook(
                     Thread.ofVirtual().unstarted(storage::close));
 
-            CommandRouter router = new CommandRouter(storage);
+            String nodeId = resolveNodeId();
+            CrdtStore crdtStore = new CrdtStore(storage, nodeId);
+            LOG.info("CrdtStore enabled (nodeId={})", nodeId);
+
+            CommandRouter router = new CommandRouter(storage, crdtStore);
             KiraDBChannelHandler handler = new KiraDBChannelHandler(router);
             start(CLIENT_PORT, handler);
         } catch (java.io.IOException e) {

--- a/kiradb-server/src/main/java/io/kiradb/server/command/CommandRouter.java
+++ b/kiradb-server/src/main/java/io/kiradb/server/command/CommandRouter.java
@@ -1,5 +1,7 @@
 package io.kiradb.server.command;
 
+import io.kiradb.crdt.CrdtStore;
+import io.kiradb.server.command.handlers.CrdtHandler;
 import io.kiradb.server.command.handlers.DelHandler;
 import io.kiradb.server.command.handlers.ExistsHandler;
 import io.kiradb.server.command.handlers.ExpireHandler;
@@ -29,14 +31,26 @@ public final class CommandRouter {
 
     private final Map<String, CommandHandler> handlers = new HashMap<>();
     private final StorageEngine storage;
+    private final CrdtStore crdtStore;
 
     /**
-     * Create a router wired to the given storage engine.
+     * Create a router with no CRDT support. Convenience for tests that don't exercise CRDT commands.
      *
      * @param storage the storage engine all handlers will read/write
      */
     public CommandRouter(final StorageEngine storage) {
+        this(storage, null);
+    }
+
+    /**
+     * Create a router wired to the given storage engine and (optionally) a CRDT store.
+     *
+     * @param storage   the storage engine all handlers will read/write
+     * @param crdtStore the CRDT store; if null, {@code CRDT.*} commands are not registered
+     */
+    public CommandRouter(final StorageEngine storage, final CrdtStore crdtStore) {
         this.storage = storage;
+        this.crdtStore = crdtStore;
         registerBuiltins();
     }
 
@@ -75,6 +89,22 @@ public final class CommandRouter {
         register("PEXPIRE", new ExpireHandler(true));
         register("SETEX", new SetExHandler(false));
         register("PSETEX", new SetExHandler(true));
+
+        if (crdtStore != null) {
+            CrdtHandler crdt = new CrdtHandler(crdtStore);
+            register("CRDT.INCR", crdt);
+            register("CRDT.GET", crdt);
+            register("CRDT.PNADD", crdt);
+            register("CRDT.PNGET", crdt);
+            register("CRDT.LWWSET", crdt);
+            register("CRDT.LWWGET", crdt);
+            register("CRDT.MVSET", crdt);
+            register("CRDT.MVGET", crdt);
+            register("CRDT.SADD", crdt);
+            register("CRDT.SREM", crdt);
+            register("CRDT.SMEMBERS", crdt);
+            register("CRDT.MERGE", crdt);
+        }
     }
 
     /**

--- a/kiradb-server/src/main/java/io/kiradb/server/command/handlers/CrdtHandler.java
+++ b/kiradb-server/src/main/java/io/kiradb/server/command/handlers/CrdtHandler.java
@@ -1,0 +1,203 @@
+package io.kiradb.server.command.handlers;
+
+import io.kiradb.core.storage.StorageEngine;
+import io.kiradb.crdt.CrdtStore;
+import io.kiradb.crdt.MVRegister;
+import io.kiradb.server.command.Command;
+import io.kiradb.server.command.CommandHandler;
+import io.kiradb.server.resp3.Resp3Value;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Single dispatcher for all {@code CRDT.*} commands.
+ *
+ * <p>One handler is registered under every CRDT command name. The dispatcher
+ * branches on {@link Command#name()} so all CRDT commands share the same
+ * {@link CrdtStore} reference without duplication.
+ *
+ * <h2>Command summary</h2>
+ * <pre>
+ *   CRDT.INCR      name [delta]                  — GCounter increment
+ *   CRDT.GET       name                          — GCounter value
+ *   CRDT.PNADD     name delta                    — PNCounter add (signed)
+ *   CRDT.PNGET     name                          — PNCounter value
+ *   CRDT.LWWSET    name value                    — LWWRegister set
+ *   CRDT.LWWGET    name                          — LWWRegister get
+ *   CRDT.MVSET     name value                    — MVRegister write
+ *   CRDT.MVGET     name                          — MVRegister read (array of concurrent values)
+ *   CRDT.SADD      name member                   — ORSet add
+ *   CRDT.SREM      name member                   — ORSet remove
+ *   CRDT.SMEMBERS  name                          — ORSet members
+ *   CRDT.MERGE     type name base64-state        — gossip merge (type ∈ {GCOUNTER})
+ * </pre>
+ */
+public final class CrdtHandler implements CommandHandler {
+
+    private final CrdtStore crdtStore;
+
+    /**
+     * Construct the dispatcher with the given store.
+     *
+     * @param crdtStore store owning all CRDT instances
+     */
+    public CrdtHandler(final CrdtStore crdtStore) {
+        this.crdtStore = crdtStore;
+    }
+
+    @Override
+    public Resp3Value execute(final Command command, final StorageEngine storage) {
+        return switch (command.name()) {
+            case "CRDT.INCR" -> handleIncr(command);
+            case "CRDT.GET" -> handleGet(command);
+            case "CRDT.PNADD" -> handlePnAdd(command);
+            case "CRDT.PNGET" -> handlePnGet(command);
+            case "CRDT.LWWSET" -> handleLwwSet(command);
+            case "CRDT.LWWGET" -> handleLwwGet(command);
+            case "CRDT.MVSET" -> handleMvSet(command);
+            case "CRDT.MVGET" -> handleMvGet(command);
+            case "CRDT.SADD" -> handleSAdd(command);
+            case "CRDT.SREM" -> handleSRem(command);
+            case "CRDT.SMEMBERS" -> handleSMembers(command);
+            case "CRDT.MERGE" -> handleMerge(command);
+            default -> Resp3Value.error("ERR unknown CRDT subcommand '" + command.name() + "'");
+        };
+    }
+
+    private Resp3Value handleIncr(final Command command) {
+        if (command.arity() < 1 || command.arity() > 2) {
+            return Resp3Value.wrongArity("CRDT.INCR");
+        }
+        String name = command.argAsString(0);
+        long delta = command.arity() == 2 ? Long.parseLong(command.argAsString(1)) : 1L;
+        if (delta <= 0) {
+            return Resp3Value.error("ERR CRDT.INCR delta must be positive");
+        }
+        long newValue = crdtStore.gCounterIncrement(name, delta);
+        return new Resp3Value.RespInteger(newValue);
+    }
+
+    private Resp3Value handleGet(final Command command) {
+        if (command.arity() != 1) {
+            return Resp3Value.wrongArity("CRDT.GET");
+        }
+        return new Resp3Value.RespInteger(crdtStore.gCounterValue(command.argAsString(0)));
+    }
+
+    private Resp3Value handlePnAdd(final Command command) {
+        if (command.arity() != 2) {
+            return Resp3Value.wrongArity("CRDT.PNADD");
+        }
+        String name = command.argAsString(0);
+        long delta = Long.parseLong(command.argAsString(1));
+        long newValue = crdtStore.pnCounterAdd(name, delta);
+        return new Resp3Value.RespInteger(newValue);
+    }
+
+    private Resp3Value handlePnGet(final Command command) {
+        if (command.arity() != 1) {
+            return Resp3Value.wrongArity("CRDT.PNGET");
+        }
+        return new Resp3Value.RespInteger(crdtStore.pnCounterValue(command.argAsString(0)));
+    }
+
+    private Resp3Value handleLwwSet(final Command command) {
+        if (command.arity() != 2) {
+            return Resp3Value.wrongArity("CRDT.LWWSET");
+        }
+        crdtStore.lwwSet(command.argAsString(0), command.argAsBytes(1));
+        return Resp3Value.ok();
+    }
+
+    private Resp3Value handleLwwGet(final Command command) {
+        if (command.arity() != 1) {
+            return Resp3Value.wrongArity("CRDT.LWWGET");
+        }
+        byte[] value = crdtStore.lwwGet(command.argAsString(0));
+        return value == null ? Resp3Value.nil() : new Resp3Value.BulkString(value);
+    }
+
+    private Resp3Value handleMvSet(final Command command) {
+        if (command.arity() != 2) {
+            return Resp3Value.wrongArity("CRDT.MVSET");
+        }
+        MVRegister r = crdtStore.mvRegister(command.argAsString(0));
+        synchronized (r) {
+            r.set(command.argAsBytes(1));
+        }
+        return Resp3Value.ok();
+    }
+
+    private Resp3Value handleMvGet(final Command command) {
+        if (command.arity() != 1) {
+            return Resp3Value.wrongArity("CRDT.MVGET");
+        }
+        MVRegister r = crdtStore.mvRegister(command.argAsString(0));
+        List<byte[]> vals = r.values();
+        List<Resp3Value> elements = new ArrayList<>(vals.size());
+        for (byte[] v : vals) {
+            elements.add(new Resp3Value.BulkString(v));
+        }
+        return new Resp3Value.RespArray(elements);
+    }
+
+    private Resp3Value handleSAdd(final Command command) {
+        if (command.arity() < 2) {
+            return Resp3Value.wrongArity("CRDT.SADD");
+        }
+        String name = command.argAsString(0);
+        for (int i = 1; i < command.arity(); i++) {
+            crdtStore.orSetAdd(name, command.argAsString(i));
+        }
+        return new Resp3Value.RespInteger(command.arity() - 1);
+    }
+
+    private Resp3Value handleSRem(final Command command) {
+        if (command.arity() < 2) {
+            return Resp3Value.wrongArity("CRDT.SREM");
+        }
+        String name = command.argAsString(0);
+        long removed = 0;
+        for (int i = 1; i < command.arity(); i++) {
+            if (crdtStore.orSetRemove(name, command.argAsString(i))) {
+                removed++;
+            }
+        }
+        return new Resp3Value.RespInteger(removed);
+    }
+
+    private Resp3Value handleSMembers(final Command command) {
+        if (command.arity() != 1) {
+            return Resp3Value.wrongArity("CRDT.SMEMBERS");
+        }
+        Set<String> members = crdtStore.orSet(command.argAsString(0)).elements();
+        List<Resp3Value> elements = new ArrayList<>(members.size());
+        for (String m : members) {
+            elements.add(new Resp3Value.BulkString(m.getBytes(StandardCharsets.UTF_8)));
+        }
+        return new Resp3Value.RespArray(elements);
+    }
+
+    private Resp3Value handleMerge(final Command command) {
+        if (command.arity() != 3) {
+            return Resp3Value.wrongArity("CRDT.MERGE");
+        }
+        String type = command.argAsString(0).toUpperCase();
+        String name = command.argAsString(1);
+        byte[] state;
+        try {
+            state = Base64.getDecoder().decode(command.argAsString(2));
+        } catch (IllegalArgumentException e) {
+            return Resp3Value.error("ERR CRDT.MERGE state must be valid base64");
+        }
+        if (!"GCOUNTER".equals(type)) {
+            return Resp3Value.error("ERR unsupported CRDT.MERGE type '" + type + "'");
+        }
+        crdtStore.mergeGCounter(name, state);
+        return Resp3Value.ok();
+    }
+}

--- a/kiradb-server/src/test/java/io/kiradb/server/CrdtIntegrationTest.java
+++ b/kiradb-server/src/test/java/io/kiradb/server/CrdtIntegrationTest.java
@@ -1,0 +1,177 @@
+package io.kiradb.server;
+
+import io.kiradb.core.storage.StorageEngine;
+import io.kiradb.core.storage.lsm.LsmStorageEngine;
+import io.kiradb.crdt.CrdtStore;
+import io.kiradb.server.command.CommandRouter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.SafeEncoder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end test of the {@code CRDT.*} RESP3 commands through the real Netty
+ * pipeline, using Jedis as the client. Phase 6's class-level tests prove the
+ * math is right; this test proves the wire path is right.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CrdtIntegrationTest {
+
+    private static final int TEST_PORT = 16380;
+
+    private Thread serverThread;
+    private StorageEngine storage;
+    private Jedis jedis;
+
+    /** Wraps a command name as a Jedis ProtocolCommand. */
+    private record Cmd(String name) implements ProtocolCommand {
+        @Override
+        public byte[] getRaw() {
+            return name.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    @BeforeAll
+    void startServer(@TempDir Path dataDir) throws Exception {
+        storage = new LsmStorageEngine(dataDir);
+        CrdtStore crdtStore = new CrdtStore(storage, "test-node");
+        CommandRouter router = new CommandRouter(storage, crdtStore);
+        KiraDBChannelHandler handler = new KiraDBChannelHandler(router);
+
+        serverThread = Thread.ofVirtual().start(() -> {
+            try {
+                KiraDBServer.start(TEST_PORT, handler);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        Thread.sleep(500);
+        jedis = new Jedis("localhost", TEST_PORT);
+    }
+
+    @AfterAll
+    void stopServer() throws IOException {
+        if (jedis != null) {
+            jedis.close();
+        }
+        if (storage != null) {
+            storage.close();
+        }
+        if (serverThread != null) {
+            serverThread.interrupt();
+        }
+    }
+
+    @Test
+    void gCounterIncrAndGet() {
+        Object first = jedis.sendCommand(new Cmd("CRDT.INCR"), "votes");
+        assertEquals(1L, first);
+
+        Object after5 = jedis.sendCommand(new Cmd("CRDT.INCR"), "votes", "5");
+        assertEquals(6L, after5);
+
+        Object value = jedis.sendCommand(new Cmd("CRDT.GET"), "votes");
+        assertEquals(6L, value);
+    }
+
+    @Test
+    void pnCounterAddSignedValues() {
+        Object after100 = jedis.sendCommand(new Cmd("CRDT.PNADD"), "balance", "100");
+        assertEquals(100L, after100);
+
+        Object after30Withdraw = jedis.sendCommand(
+                new Cmd("CRDT.PNADD"), "balance", "-30");
+        assertEquals(70L, after30Withdraw);
+
+        Object value = jedis.sendCommand(new Cmd("CRDT.PNGET"), "balance");
+        assertEquals(70L, value);
+    }
+
+    @Test
+    void lwwSetAndGet() {
+        Object setReply = jedis.sendCommand(
+                new Cmd("CRDT.LWWSET"), "flag.dark-mode", "true");
+        assertEquals("OK", SafeEncoder.encode((byte[]) setReply));
+
+        Object getReply = jedis.sendCommand(new Cmd("CRDT.LWWGET"), "flag.dark-mode");
+        assertEquals("true", SafeEncoder.encode((byte[]) getReply));
+    }
+
+    @Test
+    void lwwGetReturnsNilWhenAbsent() {
+        Object reply = jedis.sendCommand(new Cmd("CRDT.LWWGET"), "no-such-flag-xyz");
+        assertNull(reply);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void mvRegisterRoundTrip() {
+        jedis.sendCommand(new Cmd("CRDT.MVSET"), "doc.title", "First Edit");
+        Object reply = jedis.sendCommand(new Cmd("CRDT.MVGET"), "doc.title");
+        List<byte[]> values = (List<byte[]>) reply;
+        assertEquals(1, values.size());
+        assertEquals("First Edit", SafeEncoder.encode(values.get(0)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void orSetAddRemoveMembers() {
+        jedis.sendCommand(new Cmd("CRDT.SADD"), "online-users", "alice", "bob");
+
+        Object listReply = jedis.sendCommand(new Cmd("CRDT.SMEMBERS"), "online-users");
+        Set<String> members = decodeStringSet((List<byte[]>) listReply);
+        assertTrue(members.contains("alice"));
+        assertTrue(members.contains("bob"));
+        assertEquals(2, members.size());
+
+        Object removed = jedis.sendCommand(new Cmd("CRDT.SREM"), "online-users", "alice");
+        assertEquals(1L, removed);
+
+        Object afterRemove = jedis.sendCommand(new Cmd("CRDT.SMEMBERS"), "online-users");
+        Set<String> remaining = decodeStringSet((List<byte[]>) afterRemove);
+        assertEquals(Set.of("bob"), remaining);
+    }
+
+    @Test
+    void crdtMergeAcceptsBase64GCounterState() {
+        // Local node bumps its own slot
+        jedis.sendCommand(new Cmd("CRDT.INCR"), "global-events", "10");
+
+        // Peer (different node id) bumps its slot independently and ships state.
+        io.kiradb.crdt.GCounter peerCounter = new io.kiradb.crdt.GCounter("peer-node");
+        peerCounter.increment(7);
+        String b64 = Base64.getEncoder().encodeToString(peerCounter.serialize());
+
+        Object mergeReply = jedis.sendCommand(
+                new Cmd("CRDT.MERGE"), "GCOUNTER", "global-events", b64);
+        assertEquals("OK", SafeEncoder.encode((byte[]) mergeReply));
+
+        Object total = jedis.sendCommand(new Cmd("CRDT.GET"), "global-events");
+        assertEquals(17L, total);
+    }
+
+    private static Set<String> decodeStringSet(final List<byte[]> raw) {
+        Set<String> out = new HashSet<>();
+        for (byte[] b : raw) {
+            out.add(SafeEncoder.encode(b));
+        }
+        return out;
+    }
+}


### PR DESCRIPTION
- Implemented GCounter, LWWRegister, MVRegister, ORSet, and PNCounter with unit tests.
- Added integration tests for CRDT commands using Jedis.
- Enhanced KiraDBServer to support CRDT operations with a new CrdtStore.
- Updated CommandRouter to register CRDT command handlers.
- Created CrdtHandler to manage CRDT command execution.
- Added serialization and merging capabilities for CRDTs.
- Ensured CRDT operations are idempotent and commutative.